### PR TITLE
:bug: fix:fix animation playback stutter caused by 1ms sleep loop

### DIFF
--- a/MainWindowThread.py
+++ b/MainWindowThread.py
@@ -74,12 +74,12 @@ class DrawAnimationThread(QThread):
         pixmap = pixmap.scaled(self.pos[2], self.pos[3], Qt.KeepAspectRatio, Qt.SmoothTransformation)
         self.label.setPixmap(pixmap)
         
-        # 将大延迟拆分为小间隔，以便更频繁检查停止标志
-        delay_ms = int(1000 / self.frame_speed)
-        for _ in range(delay_ms):
-            if not self.running:
-                return False
-            self.msleep(1)
+        # 休眠到下一帧，避免 1ms 粒度循环在部分系统上被调度成 10~16ms，
+        # 导致 30fps 被拖慢到约 3~5fps。
+        delay_ms = max(1, int(1000 / self.frame_speed))
+        self.msleep(delay_ms)
+        if not self.running:
+            return False
         return True
 
     def run(self):


### PR DESCRIPTION
### Motivation
- Playback in work/play modes in Windows suffered from very low observed FPS because the per-frame delay was implemented as a loop of `msleep(1)`, which on many systems is coalesced by the scheduler into ~10–16ms granularity and reduces a 30 FPS target to ~3–5 FPS. 

### Description
- Replace the millisecond polling loop with a single `msleep(delay_ms)` (using `delay_ms = max(1, int(1000 / self.frame_speed))`) in `DrawAnimationThread` (`MainWindowThread.py`), preserve the stop check after sleeping, and add comments explaining the change. 

### Testing
- Ran `python -m py_compile MainWindowThread.py` which succeeded. 
- Verified source videos (`src/mp4/work.mp4`, `src/mp4/play.mp4`) are 30 FPS via an OpenCV check, supporting that the bottleneck was frame pacing in code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698706c59a3c8333aa4e3f38f8cc2300)