### PR TITLE
👷 ci: add Windows + Linux (deb) build workflows; run builds on every PR.

### DIFF
--- a/.github/workflows/build-linux-deb.yml
+++ b/.github/workflows/build-linux-deb.yml
@@ -1,0 +1,104 @@
+name: Build Linux DEB (One-File Binary)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux-deb:
+    name: Build Linux DEB (x64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract Version
+        shell: bash
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="dev-$(git rev-parse --short HEAD)"
+          fi
+          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Detected Version: $VERSION"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev libgl1 libglib2.0-0 libdbus-1-3 libxkbcommon-x11-0
+
+      - name: Install Python deps
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build one-file binary
+        shell: bash
+        run: |
+          rm -rf build dist
+          pyinstaller \
+            --clean \
+            --noconfirm \
+            --windowed \
+            --onefile \
+            --name yasumi-clock \
+            --add-data "yasumi_config.yml:." \
+            --add-data "src.yml:." \
+            --add-data "src:src" \
+            yasumi_clock.py
+
+      - name: Package DEB
+        shell: bash
+        run: |
+          PKG_ROOT="pkg"
+          VERSION="${{ env.APP_VERSION }}"
+          ARCH="amd64"
+
+          rm -rf "$PKG_ROOT"
+          mkdir -p "$PKG_ROOT/DEBIAN"
+          mkdir -p "$PKG_ROOT/usr/local/bin"
+
+          install -m 755 "dist/yasumi-clock" "$PKG_ROOT/usr/local/bin/yasumi-clock"
+
+          {
+            echo "Package: yasumi-clock"
+            echo "Version: ${VERSION#v}"
+            echo "Section: utils"
+            echo "Priority: optional"
+            echo "Architecture: $ARCH"
+            echo "Maintainer: Yasumi Clock Contributors"
+            echo "Description: Yasumi Clock Pomodoro app (bundled one-file binary)"
+          } > "$PKG_ROOT/DEBIAN/control"
+
+          mkdir -p dist/output
+          DEB_NAME="YasumiClock-${VERSION}-linux-${ARCH}.deb"
+          dpkg-deb --build "$PKG_ROOT" "dist/output/$DEB_NAME"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: YasumiClock-${{ env.APP_VERSION }}-linux-amd64-deb
+          path: dist/output/YasumiClock-${{ env.APP_VERSION }}-linux-amd64.deb
+
+      - name: Upload to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/output/YasumiClock-${{ env.APP_VERSION }}-linux-amd64.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-linux-deb.yml
+++ b/.github/workflows/build-linux-deb.yml
@@ -24,11 +24,17 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
+            DEB_VERSION=${VERSION#v}
           else
-            VERSION="dev-$(git rev-parse --short HEAD)"
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            VERSION="dev-${SHORT_SHA}"
+            # Debian version must start with a digit on non-tag builds.
+            DEB_VERSION="0.0.0+dev.${SHORT_SHA}"
           fi
           echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Detected Version: $VERSION"
+          echo "DEB_VERSION=$DEB_VERSION" >> $GITHUB_ENV
+          echo "Detected APP_VERSION: $VERSION"
+          echo "Detected DEB_VERSION: $DEB_VERSION"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -67,6 +73,7 @@ jobs:
         run: |
           PKG_ROOT="pkg"
           VERSION="${{ env.APP_VERSION }}"
+          DEB_VERSION="${{ env.DEB_VERSION }}"
           ARCH="amd64"
 
           rm -rf "$PKG_ROOT"
@@ -77,7 +84,7 @@ jobs:
 
           {
             echo "Package: yasumi-clock"
-            echo "Version: ${VERSION#v}"
+            echo "Version: ${DEB_VERSION}"
             echo "Section: utils"
             echo "Priority: optional"
             echo "Architecture: $ARCH"

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -2,16 +2,13 @@ name: Build macOS Only
 
 # 触发机制：
 # 1. 当你推送 v* 标签时（发布版本），执行构建并上传到 Release 页面
-# 2. 当你在 Pull Request 中修改了 workflow 本身或 spec 文件时触发（用于测试构建脚本）
+# 2. 当有 Pull Request 时触发（用于构建测试，防止破坏性改动）
 # 3. 允许手动在 Actions 页面点击按钮触发（方便调试）
 on:
   push:
     tags:
       - 'v*'
   pull_request:
-    paths:
-      - '.github/workflows/build.yml'
-      - '*.spec'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,79 @@
+name: Build Windows One-File
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows (x64)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract Version
+        shell: bash
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="dev-$(git rev-parse --short HEAD)"
+          fi
+          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Detected Version: $VERSION"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build one-file EXE
+        shell: bash
+        run: |
+          rm -rf build dist
+          pyinstaller \
+            --clean \
+            --noconfirm \
+            --windowed \
+            --onefile \
+            --name YasumiClock \
+            --icon src/img/example.ico \
+            --add-data "yasumi_config.yml;." \
+            --add-data "src.yml;." \
+            --add-data "src;src" \
+            yasumi_clock.py
+
+      - name: Rename artifact with version
+        shell: bash
+        run: |
+          mkdir -p dist/output
+          cp "dist/YasumiClock.exe" "dist/output/YasumiClock-${{ env.APP_VERSION }}-windows-x64.exe"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: YasumiClock-${{ env.APP_VERSION }}-windows-x64
+          path: dist/output/YasumiClock-${{ env.APP_VERSION }}-windows-x64.exe
+
+      - name: Upload to Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/output/YasumiClock-${{ env.APP_VERSION }}-windows-x64.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
新增 windows-build 和 linux-build-deb 工作流分支，并作为任意 PR 的检查条件避免破坏构建的 PR 引入。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69870efd58748333a8f1e819d97b34f0)